### PR TITLE
Update client.lua

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -1,4 +1,4 @@
-QBCore = nil
+local QBCore = exports['qb-core']:GetCoreObject()
 
 local searched = {3423423424}
 local canSearch = true
@@ -12,13 +12,6 @@ local listening = false
 local dumpster
 local currentCoords = nil
 local realDumpster
-
-Citizen.CreateThread(function() 
-    while QBCore == nil do
-        TriggerEvent("QBCore:GetObject", function(obj) QBCore = obj end)    
-        Citizen.Wait(200)
-    end
-end)
 
 function DrawText3D(x, y, z, text)
     SetTextScale(0.35, 0.35)

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,4 +1,4 @@
-QBCore = nil
+local QBCore = exports['qb-core']:GetCoreObject()
 TriggerEvent('QBCore:GetObject', function(obj) QBCore = obj end)
 
 local timer = Config.WaitTime * 60 * 1000


### PR DESCRIPTION
Replaced qbcore get object.

Getting error of qbcore nill value, replaced via the new local QBCore = exports['qb-core']:GetCoreObject()
fixed.